### PR TITLE
Add release maven artifacts github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: Publish release
+
+on:
+  workflow_dispatch:
+
+env:
+  JAVA_VERSION: ${{ vars.JAVA_VERSION }}
+  JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION }}
+  MAVEN_OPTS: ${{ vars.MAVEN_OPTS }}
+  GPG_KEY_FILE: /tmp/gpg-key.txt
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    environment: release
+    strategy:
+      fail-fast: true
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Check branch
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: echo "Invalid branch. This action can only be run on the master branch." && exit 1
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRESTODB_CI_TOKEN }}
+          show-progress: false
+          fetch-depth: 0
+          ref: master
+
+      - name: Set up JDK ${{ env.JAVA_DISTRIBUTION }}/${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          overwrite-settings: true
+          server-id: ossrh
+          server-username: NEXUS_USERNAME
+          server-password: NEXUS_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_SECRET }}
+
+      - name: Set up git
+        run: |
+          git config --global --add safe.directory ${{github.workspace}}
+          git config --global user.email "ci@lists.prestodb.io"
+          git config --global user.name "prestodb-ci"
+          git config --global alias.ls 'log --pretty=format:"%cd %h %ce: %s" --date=short --no-merges'
+          git config pull.rebase false
+
+      - name: Get release version
+        id: get-version
+        run: |
+          RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1 | sed 's/-SNAPSHOT//')
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$RELEASE_VERSION"
+          echo "In case cut release failed, please delete the tag ${RELEASE_VERSION} manually"
+
+      - name: Prepare release
+        run: |
+          git reset --hard
+          mvn release:prepare -DreleaseVersion=${{ env.RELEASE_VERSION }}
+          grep -m 1 "<version>" pom.xml
+          git ls -5
+
+      - name: Set up GPG key
+        env:
+          GPG_TTY: $(tty)
+        run: |
+          echo "${{ secrets.GPG_SECRET }}" > ${{ env.GPG_KEY_FILE }}
+          chmod 600 ${{ env.GPG_KEY_FILE }}
+          gpg --import --batch ${{ env.GPG_KEY_FILE }}
+          gpg --batch --yes --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}" --sign ${{ env.GPG_KEY_FILE }}
+
+      - name: Publish release
+        env:
+          NEXUS_USERNAME: "${{ secrets.NEXUS_USERNAME }}"
+          NEXUS_PASSWORD: "${{ secrets.NEXUS_PASSWORD }}"
+          GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
+        run: |
+          git checkout ${{ env.RELEASE_VERSION }}
+          git ls -5
+          cat ~/.m2/settings.xml
+          mvn -V -B -U -e -T2C deploy -Poss-release \
+            -DautoReleaseAfterClose=true \
+            -DkeepStagingRepositoryOnCloseRuleFailure=true \
+            -DkeepStagingRepositoryOnFailure=true \
+            -DstagingProgressTimeoutMinutes=10
+
+      - name: Push changes and tags
+        run: |
+          git checkout master
+          git ls -5
+          git push origin master --tags


### PR DESCRIPTION
To make the release action work, we need set the version as snapshot version e.g. 1.8-SNAPSHOT.

```
mvn versions:set -DnewVersion=1.8-SNAPSHOT
```

Tested with => https://github.com/unix280/resolver/actions/runs/14908389433/job/41876272389