### PR TITLE
fix(resolver):Fix classloader issue for Spark/isolated environments

### DIFF
--- a/resolver/src/main/java/com/facebook/airlift/resolver/ArtifactResolver.java
+++ b/resolver/src/main/java/com/facebook/airlift/resolver/ArtifactResolver.java
@@ -90,6 +90,16 @@ public class ArtifactResolver
             .add("http://repo.maven.apache.org/maven2/")
             .build();
 
+    private static final String MAVEN_REPOSITORY_SYSTEM_CLASS = "org.apache.maven.repository.RepositorySystem";
+    private static final String PLEXUS_CONTAINER_CLASS = "org.codehaus.plexus.DefaultPlexusContainer";
+    private static final String AETHER_REPOSITORY_SYSTEM_CLASS = "org.eclipse.aether.RepositorySystem";
+
+    /**
+     * Cached effective ClassLoader to avoid repeated Class.forName checks on every container() call.
+     * Initialized lazily on first access and reused thereafter.
+     */
+    private static volatile ClassLoader cachedEffectiveClassLoader;
+
     private final RepositorySystem repositorySystem;
     private final DefaultRepositorySystemSession repositorySystemSession;
     private final List<RemoteRepository> repositories;
@@ -327,7 +337,11 @@ public class ArtifactResolver
     {
         // TODO: move off Plexus DI, use Sisu instead
         try {
-            ClassWorld classWorld = new ClassWorld("plexus.core", Thread.currentThread().getContextClassLoader());
+            // Fix for Spark and other isolated classloader environments:
+            // Select an effective ClassLoader by checking multiple candidates to ensure Maven Resolver/Plexus components are discoverable at runtime.
+            ClassLoader classLoader = getEffectiveClassLoader();
+
+            ClassWorld classWorld = new ClassWorld("plexus.core", classLoader);
 
             ContainerConfiguration cc = new DefaultContainerConfiguration()
                     .setClassWorld(classWorld)
@@ -348,6 +362,80 @@ public class ArtifactResolver
         }
         catch (PlexusContainerException e) {
             throw new RuntimeException("Error loading Maven system", e);
+        }
+    }
+
+    /**
+     * Determine a ClassLoader that can access Maven Resolver and Plexus classes.
+     * Some isolated runtimes (e.g. Spark executors) use a TCCL that cannot see
+     * resolver dependencies, so we fall back to the resolver's defining loader.
+     */
+    private static ClassLoader getEffectiveClassLoader()
+    {
+        // First check without synchronization (fast path for already cached value)
+        ClassLoader cached = cachedEffectiveClassLoader;
+        if (cached != null) {
+            return cached;
+        }
+
+        // Synchronize for initialization to prevent race conditions
+        synchronized (ArtifactResolver.class) {
+            // Double-check after acquiring lock
+            cached = cachedEffectiveClassLoader;
+            if (cached != null) {
+                return cached;
+            }
+
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            if (contextClassLoader != null && canLoadMavenComponents(contextClassLoader)) {
+                cachedEffectiveClassLoader = contextClassLoader;
+                return cachedEffectiveClassLoader;
+            }
+
+            ClassLoader thisClassLoader = ArtifactResolver.class.getClassLoader();
+            if (thisClassLoader != null && canLoadMavenComponents(thisClassLoader)) {
+                cachedEffectiveClassLoader = thisClassLoader;
+                return cachedEffectiveClassLoader;
+            }
+
+            ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
+            if (systemClassLoader != null && canLoadMavenComponents(systemClassLoader)) {
+                cachedEffectiveClassLoader = systemClassLoader;
+                return cachedEffectiveClassLoader;
+            }
+
+            ClassLoader fallback = systemClassLoader != null ? systemClassLoader : thisClassLoader;
+            if (fallback == null) {
+                throw new IllegalStateException("Unable to determine a valid ClassLoader for Maven component initialization. " +
+                        "Both system ClassLoader and class ClassLoader are null, and no other ClassLoader can load required Maven components.");
+            }
+            cachedEffectiveClassLoader = fallback;
+
+            return cachedEffectiveClassLoader;
+        }
+    }
+
+    /**
+     * Verify whether the provided ClassLoader has visibility into essential Maven
+     * and Plexus components required for resolver initialization.
+     *
+     * @param classLoader the ClassLoader to validate
+     * @return true if required Maven and Plexus classes are visible to the ClassLoader;
+     * false otherwise
+     */
+    private static boolean canLoadMavenComponents(ClassLoader classLoader)
+    {
+        try {
+            // Verify visibility of a core Maven repository component
+            Class.forName(MAVEN_REPOSITORY_SYSTEM_CLASS, false, classLoader);
+            // Verify visibility of the Plexus container used for component discovery
+            Class.forName(PLEXUS_CONTAINER_CLASS, false, classLoader);
+            // Verify visibility of Maven Resolver API (critical for dependency resolution)
+            Class.forName(AETHER_REPOSITORY_SYSTEM_CLASS, false, classLoader);
+            return true;
+        }
+        catch (ClassNotFoundException e) {
+            return false;
         }
     }
 }


### PR DESCRIPTION
### Description
This change improves the reliability of Maven Resolver / Plexus initialization in environments with isolated or non-standard classloader hierarchies (e.g., Spark executors, Docker containers, or shaded runtimes).

Previously, the resolver initialization relied solely on the Thread Context ClassLoader (TCCL). In certain distributed or containerized environments, the TCCL may not have visibility into required Maven components, resulting in runtime failures such as:

- RepositorySystem initialization errors

- ServiceLoader lookup failures

- PlexusContainer component discovery failures

This PR introduces a defensive classloader selection mechanism that evaluates multiple candidate classloaders and selects the first one capable of loading the required Maven components.

### Motivation and Context
In distributed and containerized environments (such as Spark), classloader isolation can prevent the Thread Context ClassLoader from accessing required Maven components. This leads to runtime failures even when dependencies are present on the classpath, resulting in errors observed in Spark Docker containers during Maven Resolver initialization.


```
Caused by: org.codehaus.plexus.component.repository.exception.ComponentLookupException: java.util.NoSuchElementException
      role: org.apache.maven.repository.RepositorySystem
  roleHint: 
	at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:267)
	at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:255)
	at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:249)
	at com.facebook.airlift.resolver.ArtifactResolver.buildProjectBuilder(ArtifactResolver.java:218)
	... 40 more
Caused by: java.util.NoSuchElementException
	at org.eclipse.sisu.inject.LocatedBeans$Itr.next(LocatedBeans.java:141)
	at org.eclipse.sisu.inject.LocatedBeans$Itr.next(LocatedBeans.java:1)
	at org.eclipse.sisu.plexus.DefaultPlexusBeans$Itr.next(DefaultPlexusBeans.java:76)
	at org.eclipse.sisu.plexus.DefaultPlexusBeans$Itr.next(DefaultPlexusBeans.java:1)
	at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:263)
	... 43 more
```

This issue is caused by the changes introduced in the Airlift Resolver 1.7 PR : https://github.com/prestodb/resolver/pull/2


### Testing

Tested on OSS Presto PR by the help of jitpack : https://github.com/prestodb/presto/pull/25295