### PR TITLE
fix(security): upgrade plexus-utils version to 4.0.3 to address CVE-2025-67030

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
-                <version>3.5.1</version>
+                <version>4.0.3</version>
             </dependency>
 
             <!-- DI: Sisu -->

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -82,6 +82,19 @@
 
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-xml</artifactId>
+            <version>4.0.4</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-classworlds</artifactId>
         </dependency>
 


### PR DESCRIPTION
Upgrade plexus-utils version to 4.0.3 to address CVE-2025-67030.

The upgrade to **plexus-utils 4.0.3** introduced a breaking change where XML parsing classes (e.g., XmlPullParserException) were removed from plexus-utils and moved to a separate library, **plexus-xml.**

To maintain compatibility with Maven's XML processing requirements, the repository now uses plexus-utils 4.0.3 as specified in the root pom.xml, along with the required **plexus-xml** dependency as a runtime dependency.