### PR TITLE
fix(ci): Add missing project name for publishing

### DIFF
--- a/resolver-integration/pom.xml
+++ b/resolver-integration/pom.xml
@@ -9,6 +9,7 @@
 
     <artifactId>resolver-integration</artifactId>
     <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
 
     <properties>
         <air.check.skip-jacoco>true</air.check.skip-jacoco>

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>resolver</artifactId>
+    <name>${project.artifactId}</name>
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>


### PR DESCRIPTION
Fix the errors when publishing:

```
Deployment c483672e-61fa-43a6-a65e-1c5026ebcdd2 failed
pkg:maven/com.facebook.airlift.resolver/resolver-integration@1.8:
 - Project name is missing

pkg:maven/com.facebook.airlift.resolver/resolver@1.8:
 - Project name is missing

```